### PR TITLE
#160984490 - Bug fix on GET articles endpoint

### DIFF
--- a/controllers/article/ArticleController.js
+++ b/controllers/article/ArticleController.js
@@ -53,12 +53,9 @@ export default class ArticleController {
   static async getArticles(req, res) {
     const { size } = req.query;
     let { page } = req.query;
-    let offset;
+
     const pageNumber = Number(page);
-    if (!Number.isNaN(pageNumber) && pageNumber > 0) {
-      offset = page;
-    } else {
-      offset = 1;
+    if (!(!Number.isNaN(pageNumber) && pageNumber > 0)) {
       page = 1;
     }
     let limit;
@@ -73,9 +70,10 @@ export default class ArticleController {
     const totalArticle = await Article.findAndCountAll();
 
     const total = totalArticle.count;
-    const totalPages = Math.ceil(total / limit);
-    offset = Math.min(totalPages, offset);
-    offset = (offset - 1) * limit;
+    let totalPages = Math.ceil(total / limit);
+    if (!totalPages) totalPages = 1;
+    page = Math.min(totalPages, page);
+    const offset = (page - 1) * limit;
 
     const allArticle = await Article.findAll({
       limit,

--- a/tests/routes/articleRoute.test.js
+++ b/tests/routes/articleRoute.test.js
@@ -104,6 +104,15 @@ describe('Article CRUD Test', () => {
       response.body.should.be.a('object');
       assertArrayResponse(response, 10);
     });
+    it('should return an empty list of articles', async () => {
+      await deleteArticlesFromTable();
+      const response = await chai.request(server)
+        .get('/api/v1/articles')
+        .send();
+      assertResponseStatus(response, 200);
+      response.body.should.be.a('object');
+      assertArrayResponse(response, 0);
+    });
     it('should return list of articles with pagination', async () => {
       let response = await chai.request(server)
         .get('/api/v1/articles?page=1&size=3')


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug in the API when a user tries to retrieving an empty article list.
#### Description of Task to be completed?
- Fixed error 'SequelizeDatabaseError: OFFSET must not be negative' throw in ArticleController.getArticles method
- Updated test suites
#### How should this be manually tested?
- Fetch and checkout to the branch
```$xslt
> git fetch
> git checkout bug-160984490-bug-fix-get-articles-endpoint 
> npm install 
```
- Setup database using .env-sample
* Run Sequelize migration 
```$xslt
 > npm run migration
 ```
- Run application
```$xslt 
> npm run start
```
- To run test
```$xslt 
> npm run test
```

* Using a REST client such as postman to test endpoints: 
To get list of articles: `GET /api/v1/articles`, for paginated result:`GET /api/v1/articles?page=1&size=5`

#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
- [#160984490](<https://www.pivotaltracker.com/story/show/160984490>)
#### Screenshots (if appropriate)
<img width="1355" alt="screen shot 2018-10-04 at 1 20 43 pm" src="https://user-images.githubusercontent.com/15909231/46473876-61f3d300-c7d9-11e8-97cb-16315c87e213.png">


#### Questions: