### PR TITLE
#160452477 Users should be able to reset password via email

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -11,4 +11,5 @@
 # JWTSECRET=
 # SENDGRID_API_KEY=
 # HOST_EMAIL=
-# BASE_URL=http://example.com/api/v1/
+# BASE_URL=http://example.com/api/v1
+# PASSWORD_RESET_EXPIRY=

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,7 @@
 export default {
   secret:
         process.env.NODE_ENV === 'production' ? process.env.SECRET : 'secret',
+  baseUrl: process.env.BASE_URL,
+  jwtSecret: process.env.JWTSECRET,
+  passwordResetExpiry: process.env.PASSWORD_RESET_EXPIRY || '5h',
 };

--- a/controllers/user/UserController.js
+++ b/controllers/user/UserController.js
@@ -1,0 +1,104 @@
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import logger from '../../helpers/logger';
+import db from '../../models/index';
+import UserHelper from '../../helpers/UserHelper';
+import Util from '../../helpers/Util';
+import Mailer from '../../services/Mail';
+import config from '../../config';
+
+const { User } = db;
+/**
+ * UserController
+ */
+export default class UserController {
+  /**
+   *
+   *
+   * @static
+   * @param {request} req
+   * @param {response} res
+   * @param {next} next
+   * @returns {json} return json object to user
+   * @memberof UserController
+   */
+  static async beginResetPassword(req, res, next) {
+    const { email } = req.body;
+    try {
+      const user = await UserHelper.findByEmail(email);
+      if (user) {
+        const { id, updatedAt } = user;
+        const resetToken = Util.generateToken({ id, updatedAt },
+          Util.dateToString(updatedAt));
+        const url = `${config.baseUrl}/users/reset-password/complete/${resetToken}`;
+        Mailer.sendPasswordReset(email, url)
+          .then(({ status, message }) => {
+            if (status !== 'success') {
+              logger.error(message);
+            }
+          })
+          .catch((error) => {
+            logger.error(error);
+          });
+        return res.status(200)
+          .json({
+            status: 'success',
+            message: 'An email containing the reset password link has been sent to you. If you can\'t find the link, please try again.'
+          });
+      }
+      return res.status(400).json({
+        status: 'error',
+        message: 'Oops! user not found'
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {object} a response object
+   * @memberof UserController
+   */
+  static async completePasswordReset(req, res) {
+    const { token } = req.params;
+    const { password } = req.body;
+    try {
+      const { id } = await jwt.decode(token);
+      const user = await User.findById(id);
+      if (!user) {
+        return res.status(400).json({
+          status: 'error',
+          message: 'Oops! user not found'
+        });
+      }
+      const { updatedAt } = user;
+      await jwt.verify(token, Util.dateToString(updatedAt));
+      await user.update(
+        {
+          password: bcrypt.hashSync(password, 10),
+        },
+        {
+          where: {
+            id
+          }
+        }
+      );
+      return res.status(200).json({
+        status: 'success',
+        message: 'Password has been successfully reset!',
+      });
+    } catch (error) {
+      const message = (error instanceof jwt.JsonWebTokenError) ? 'Invalid password reset token' : error.message;
+      res.status(400).json({
+        status: 'error',
+        message
+      });
+    }
+  }
+}

--- a/helpers/UserHelper.js
+++ b/helpers/UserHelper.js
@@ -1,5 +1,4 @@
 import db from '../models';
-import logger from './exceptionHandler/errorHandler';
 
 const { User } = db;
 
@@ -25,7 +24,7 @@ class UserHelper {
       }
       return null;
     } catch (e) {
-      throw new Error('Somthing went wrong', e);
+      throw new Error('Something went wrong', e);
     }
   }
 
@@ -41,7 +40,7 @@ class UserHelper {
     try {
       data = await User.findOne({ where: { id } });
     } catch (e) {
-      logger.error(e);
+      throw new Error('Something went wrong', e);
     }
     return data;
   }

--- a/helpers/Util.js
+++ b/helpers/Util.js
@@ -1,5 +1,7 @@
+import jwt from 'jsonwebtoken';
 import urlSlug from 'url-slug';
 import { DEFAULT_LIMIT } from './constants';
+import config from '../config';
 
 /**
  * Util class
@@ -43,5 +45,33 @@ export default class Util {
     return {
       page, limit, offset
     };
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {*} data
+   * @param {*} signature
+   * @returns {string} returns encoded jwt string
+   * @memberof Util
+   */
+  static generateToken(data, signature) {
+    return jwt.sign(data,
+      signature, {
+        expiresIn: config.passwordResetExpiry,
+      });
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {*} date
+   * @returns {string} returns a string format of the timestamp
+   * @memberof Util
+   */
+  static dateToString(date) {
+    return new Date(date).getTime().toString();
   }
 }

--- a/helpers/exceptionHandler/ValidationError.js
+++ b/helpers/exceptionHandler/ValidationError.js
@@ -1,0 +1,20 @@
+
+/**
+ *
+ *
+ * @class ValidationError
+ */
+class ValidationError {
+  /**
+   *Creates an instance of ValidationError.
+   * @param {*} errors
+   * @memberof ValidationError
+   */
+  constructor(errors) {
+    this.status = 400;
+    this.message = 'Validation error';
+    this.messages = errors;
+  }
+}
+
+export default ValidationError;

--- a/helpers/exceptionHandler/errorHandler.js
+++ b/helpers/exceptionHandler/errorHandler.js
@@ -1,3 +1,5 @@
+import ValidationError from './ValidationError';
+
 /**
  * Handles operational and some programmer errors
  * @param  {object} error - Error object
@@ -8,9 +10,14 @@
  */
 
 const errorHandler = (error, req, res, next) => { // eslint-disable-line no-unused-vars
+  let { errors } = error;
+  if (error instanceof ValidationError) {
+    errors = error.messages;
+  }
   res.status(error.status || 500).json({
-    message: error.message,
-    status: 'error'
+    status: 'error',
+    message: error.message || 'An error occured',
+    errors,
   });
 };
 export default errorHandler;

--- a/middlewares/validators/UserValidator.js
+++ b/middlewares/validators/UserValidator.js
@@ -1,0 +1,49 @@
+import validate from 'validate.js';
+import Constraints from './constraints';
+import ValidationError from '../../helpers/exceptionHandler/ValidationError';
+
+/**
+ *
+ *
+ * @class UserValidator
+ */
+class UserValidator {
+  /**
+   *
+   *
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {function} returns a validator function
+   * @memberof UserValidator
+   */
+  static beginResetPassword(req, res, next) {
+    const errors = validate(req.body, Constraints.User.beginResetPassword);
+    if (errors) {
+      return next(new ValidationError(errors));
+    }
+    next();
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {function} returns a validator function
+   * @memberof UserValidator
+   */
+  static completeResetPassword(req, res, next) {
+    const errors = validate(req.body, Constraints.User.completeResetPassword);
+    if (errors) {
+      return next(new ValidationError(errors));
+    }
+    next();
+  }
+}
+
+
+export default UserValidator;

--- a/middlewares/validators/constraints/index.js
+++ b/middlewares/validators/constraints/index.js
@@ -1,0 +1,5 @@
+import UserConstraint from './modules/UserConstraint';
+
+export default {
+  User: UserConstraint,
+};

--- a/middlewares/validators/constraints/modules/UserConstraint.js
+++ b/middlewares/validators/constraints/modules/UserConstraint.js
@@ -1,0 +1,29 @@
+/**
+ *
+ *
+ * @class UserConstraint
+ */
+class UserConstraint {
+
+}
+
+UserConstraint.beginResetPassword = {
+  email: {
+    presence: true,
+    email: {
+      message: 'is invalid'
+    },
+  }
+};
+
+UserConstraint.completeResetPassword = {
+  password: {
+    presence: true,
+    length: {
+      minimum: 8,
+      message: 'must be at least 8 characters'
+    },
+  }
+};
+
+export default UserConstraint;

--- a/middlewares/validators/index.js
+++ b/middlewares/validators/index.js
@@ -1,0 +1,5 @@
+import UserValidator from './UserValidator';
+
+export default {
+  User: UserValidator,
+};

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "swagger-ui-express": "^4.0.1",
         "underscore": "^1.9.1",
         "url-slug": "^2.0.0",
+        "validate.js": "^0.12.0",
         "validator": "^10.8.0",
         "winston": "^3.1.0",
         "yamljs": "^0.3.0"
@@ -89,7 +90,8 @@
         ],
         "reporter": [
             "lcov",
-            "text"
+            "text",
+            "html"
         ]
     }
 }

--- a/routes/users/users.js
+++ b/routes/users/users.js
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import auth from '../../middlewares/Authorization';
 import userProfile from '../../controllers/user/UserProfile';
 import profileValidator from '../../middlewares/validators/ProfileValidator';
+import UserController from '../../controllers/user/UserController';
+import Validator from '../../middlewares/validators';
 
 const router = Router();
 
@@ -9,5 +11,7 @@ const router = Router();
 router.put('/', auth.verifyToken, profileValidator.validation, userProfile.updateProfile);
 router.get('/', auth.verifyToken, userProfile.getProfile);
 
+router.post('/reset-password/begin', Validator.User.beginResetPassword, UserController.beginResetPassword);
+router.post('/reset-password/complete/:token', Validator.User.completeResetPassword, UserController.completePasswordReset);
 
 export default router;

--- a/services/Mail.js
+++ b/services/Mail.js
@@ -31,11 +31,43 @@ class Mail {
       .send(messageInfo)
       .then((resp) => {
         if (resp[0].statusCode === 202) {
-          logger.info(`VERIFICATION_EMAIL_SENT: ${email}`);
+          return logger.info(`VERIFICATION_EMAIL_SENT: ${email}`);
         }
         logger.log(`VERIFICATION_EMAIL_NOT_SENT: ${email}`);
       })
       .catch(err => logger.error(`SENDGRID_ERROR: ${err.stack}`));
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {string} email
+   * @param {string} url
+   * @memberof Mail
+   * @returns {res} response
+   */
+  static async sendPasswordReset(email, url) {
+    const subject = 'Password Reset Email';
+    const { message } = emailMessages.passwordReset(url);
+    const messageInfo = MailHelper.buildMessage(email, subject, message);
+    try {
+      const response = await sgMail.send(messageInfo);
+      if (response[0].statusCode === 202) {
+        return {
+          status: 'success',
+        };
+      }
+      return {
+        status: 'error',
+        message: 'Unable to send email'
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        message: `An error occured: ${error}`,
+      };
+    }
   }
 }
 

--- a/services/mailMessage.js
+++ b/services/mailMessage.js
@@ -2,6 +2,9 @@ const emailMessages = {
   signupVerification: (email, url) => ({
     message: `<b>This is a comfimation mail for ${email} from </b>  <h1> Authors Haven </h1> <br>
 Please follow this link <a href="${url}"> ${url} </a> to confrim your registration`
-  })
+  }),
+  passwordReset: url => ({
+    message: `You requested requested a password reset, follow this link to continue <a href='${url}'>${url}</a>`
+  }),
 };
 export default emailMessages;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -540,8 +540,65 @@ paths:
       tags:
       - Users
       security:
-      - UserSecurity: []
+        - UserSecurity: []
 
+  /users/reset-password/begin:
+    post:
+      summary: Start password reset process
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          description: The email of the user who wants to reset password
+          schema:
+            $ref: "#/definitions/BeginPasswordResetRequest"
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/BeginPasswordResetResponse"
+        "400":
+          description: Bad Request
+        "500":
+          description: Server Error
+      tags:
+        - Users
+        
+  /users/reset-password/complete/{token}:
+    post:
+      summary: Complete reset password process
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: "token"
+          in: "path"
+          description: "Password reset token sent to email as part of url"
+          required: true
+          type: "string"
+        - in: body
+          name: body
+          required: true
+          description: The new password for resetting
+          schema:
+            $ref: "#/definitions/CompletePasswordResetRequest"
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/CompletePasswordResetResponse"
+        "400":
+          description: Bad Request
+        "500":
+          description: Server Error
+      tags:
+        - Users
+        
 definitions:
   UserRequest:
     required:
@@ -868,3 +925,33 @@ definitions:
       updatedAt:
         type: string
         example: 1/10/ 2018
+  BeginPasswordResetRequest: 
+    required:
+      - email
+    properties:
+      email:
+        type: string
+        example: femwal@maildomain.com
+  CompletePasswordResetRequest: 
+    required:
+      - password
+    properties:
+      password:
+        type: string
+        example: mockingjay
+  BeginPasswordResetResponse:
+    properties:
+      status:
+        type: string
+        example: success
+      message:
+        type: string
+        example: An email containing the reset password link has been sent to you. If you can't find the link, please try again.
+  CompletePasswordResetResponse:
+    properties:
+      status:
+        type: string
+        example: success
+      message:
+        type: string
+        example: Password has been successfully reset!.

--- a/tests/routes/resetPassword.test.js
+++ b/tests/routes/resetPassword.test.js
@@ -1,0 +1,151 @@
+import chai, {
+  expect
+} from 'chai';
+import server from '../../index';
+import UserHelper from '../../helpers/UserHelper';
+import Util from '../../helpers/Util';
+
+const user = {
+  email: 'resettester@havenmail.com',
+  username: 'resettester',
+  password: 'testedokay',
+};
+const beginResetEndpoint = '/api/v1/users/reset-password/begin';
+const completeResetEndpoint = '/api/v1/users/reset-password/complete';
+const {
+  email,
+  password
+} = user;
+const invalidResetToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXBkYXRlZEF0IjoiMjAxOC0xMC0wN1QxMToxODowMC41
+NjZaIiwiaWF0IjoxNTM4OTEyNTkxLCJleHAiOjE1Mzg5MzA1OTF9.WfcF4CG3QqBeXCSk4yoGFg-`;
+let unknownUserToken = '';
+let resetToken = '';
+describe('Reset Password', () => {
+  before('Register user', (done) => {
+    chai.request(server)
+      .post('/api/v1/auth/signup')
+      .send(user)
+      .end(async () => {
+        const {
+          id,
+          updatedAt
+        } = await UserHelper.findByEmail(email);
+        resetToken = Util.generateToken({
+          id
+        }, Util.dateToString(updatedAt));
+        unknownUserToken = Util.generateToken({
+          id: 419
+        }, Util.dateToString(updatedAt));
+        done();
+      });
+  });
+  describe(`POST ${beginResetEndpoint}`, () => {
+    it('should return success response if email exists', (done) => {
+      chai.request(server)
+        .post(beginResetEndpoint)
+        .send({
+          email
+        })
+        .end((err, response) => {
+          expect(response).to.have.status(200);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('success');
+          expect(response.body).to.have.property('message');
+          done();
+        });
+    });
+    it('should return error response if email does not exist', (done) => {
+      chai.request(server)
+        .post(beginResetEndpoint)
+        .send({
+          email: 'jarever555@invalidmails.com'
+        })
+        .end((err, response) => {
+          expect(response).to.have.status(400);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('error');
+          expect(response.body).to.have.property('message');
+          done();
+        });
+    });
+    it('should return error response if email is not provided', (done) => {
+      chai.request(server)
+        .post(`${beginResetEndpoint}`)
+        .end((err, response) => {
+          expect(response).to.have.status(400);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('error');
+          expect(response.body).to.have.property('message');
+          done();
+        });
+    });
+  });
+  describe(`POST ${completeResetEndpoint}`, () => {
+    it('should return success response for a valid token and password', (done) => {
+      chai.request(server)
+        .post(`${completeResetEndpoint}/${resetToken}`)
+        .send({
+          password
+        })
+        .end((err, response) => {
+          expect(response).to.have.status(200);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('success');
+          done();
+        });
+    });
+
+    it('should return error response for an invalid token', (done) => {
+      chai.request(server)
+        .post(`${completeResetEndpoint}/${invalidResetToken}`)
+        .send({
+          password
+        })
+        .end((err, response) => {
+          expect(response).to.have.status(400);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('error');
+          done();
+        });
+    });
+
+    it('should return error response if token has been used', (done) => {
+      chai.request(server)
+        .post(`${completeResetEndpoint}/${resetToken}`)
+        .send({
+          password: 'jarever555'
+        })
+        .end((err, response) => {
+          expect(response).to.have.status(400);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('error');
+          done();
+        });
+    });
+
+    it('should return error response if user does not exist', (done) => {
+      chai.request(server)
+        .post(`${completeResetEndpoint}/${unknownUserToken}`)
+        .send({
+          password: 'jarever555'
+        })
+        .end((err, response) => {
+          expect(response).to.have.status(400);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('error');
+          done();
+        });
+    });
+
+    it('should return error response if password is not provided', (done) => {
+      chai.request(server)
+        .post(`${completeResetEndpoint}/${resetToken}`)
+        .end((err, response) => {
+          expect(response).to.have.status(400);
+          expect(response.body).to.have.property('status')
+            .that.is.equal('error');
+          done();
+        });
+    });
+  });
+});

--- a/tests/services/mail.test.js
+++ b/tests/services/mail.test.js
@@ -1,0 +1,16 @@
+import chai from 'chai';
+import Mail from '../../services/Mail';
+
+const { expect } = chai;
+describe('sendPasswordReset() method', () => {
+  it('should send an email when called', (done) => {
+    Mail.sendPasswordReset('testingurl@authorshavenand.com',
+      'http://localhost:3000/api/v1/users/reset-password/complete/{token_here}')
+      .then((res) => {
+        expect(res).to.be.a('object');
+        expect(res).to.have.property('status')
+          .that.is.equal('success');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Implements reset password functionality by giving users who have forgotten their password the ability to set a new password.
#### Description of Task to be completed?
- write test for endpoints
- provide structure for error handling
- send url containing password reset token as an email to user
- ensure user cannot use the token again once details have been updated
- include command to generate html presentation of code coverage for better presentation
- update swagger documentation
#### How should this be manually tested?
- Run `git fetch` to fetch new branch
- Checkout to this branch `git checkout ft-160452477-reset-password`
- Update env file using the shared google doc. Set the value of `PASSWORD_RESET_EXPIRY`
- Run `npm install` to install dependencies
- Run `npm start` to start application
- Run `npm test` to run tests
- [see docs](http://localhost:3000/api-docs/)

[POST](http://localhost:3000/api-docs/#/Users/post_users_reset_password_begin) `/users/reset-password/begin`
 Sample request 
 ```
 {
   "email": "agfsdef@mailsdk.com"
 }
 ```
  [POST](http://localhost:3000/api-docs/#/Users/post_users_reset_password_complete__token_) `/users/reset-password/complete/{token}`
 Sample request 
 ```
 {
   "password": "jagabanoflagos"
 }
 ```
#### Any background context you want to provide?
 - none
#### What are the relevant pivotal tracker stories?
[#160452477](https://www.pivotaltracker.com/story/show/160452477)
#### Screenshots (if appropriate)
#### Questions:
- none