### PR TITLE
#160452484 Authenticated users  can like or dislike  an article

### DIFF
--- a/controllers/article/LikesController.js
+++ b/controllers/article/LikesController.js
@@ -1,0 +1,45 @@
+import db from '../../models';
+import ArticleHelper from '../../helpers/ArticleHelper';
+import HttpError from '../../helpers/exceptionHandler/httpError';
+
+const { Like } = db;
+/**
+ *
+ * @description Handles user article's like
+ * @export
+ * @class LikeController
+ */
+export default class LikeController {
+  /**
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @memberof LikeController
+   * @return {json} Returns json object
+   */
+  static async addLike(req, res) {
+    const { slug, status } = req.params;
+    const { userId } = req.authData;
+
+    const article = await ArticleHelper.findArticleBySlug(slug);
+
+
+    HttpError.throw404ErrorIfNull(article, 'Article not found');
+
+    const articleId = article.id;
+    const existingLike = await Like.findOne({ where: { $and: [{ articleId }, { userId }] } });
+
+    if (existingLike) {
+      await Like.update({ status }, { where: { $and: [{ articleId }, { userId }] } });
+      return res.status(200).json({
+        status: 'success',
+        message: 'successfully modified like status',
+      });
+    }
+    Like.create({ userId, articleId, status });
+    return res.status(201).json({
+      status: 'success',
+      message: 'successfully liked an article',
+    });
+  }
+}

--- a/middlewares/validators/LikeValidator.js
+++ b/middlewares/validators/LikeValidator.js
@@ -1,0 +1,26 @@
+/**
+ *
+ *
+ * @export
+ * @class LikeValidator
+ */
+export default class LikeValidator {
+  /**
+   * @static
+   * @param {object} req
+   * @param {object} res
+   * @param {function} next
+   * @returns {function} Returns response message
+   * @memberof LikeValidator
+   */
+  static addLikeValidator(req, res, next) {
+    const { status } = req.params;
+    if (status === 'like' || status === 'dislike' || status === 'neutral') {
+      return next();
+    }
+    return res.status(400).json({
+      status: 'error',
+      message: 'status can only be either like, dislike or neutral '
+    });
+  }
+}

--- a/migrations/20181008055245-create-like.js
+++ b/migrations/20181008055245-create-like.js
@@ -1,0 +1,41 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Likes', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    articleId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      reference: {
+        id: 'id',
+        model: 'Articles'
+      }
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      reference: {
+        id: 'id',
+        model: 'Users'
+      }
+    },
+    status: {
+      type: Sequelize.ENUM,
+      values: ['like', 'dislike', 'neutral'],
+    },
+
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+  }),
+  down: queryInterface => queryInterface.dropTable('Likes')
+};

--- a/models/article.js
+++ b/models/article.js
@@ -10,6 +10,10 @@ module.exports = (sequelize, DataTypes) => {
       as: 'user',
     });
     Article.hasMany(models.Comment, { as: 'comments', foreignKey: 'articleId' });
+    Article.hasMany(models.Like, {
+      foreignKey: 'articleId',
+      as: 'likes',
+    });
   };
 
   return Article;

--- a/models/like.js
+++ b/models/like.js
@@ -1,0 +1,19 @@
+
+module.exports = (sequelize, Sequelize) => {
+  const Like = sequelize.define('Like', {
+    articleId: Sequelize.INTEGER,
+    userId: Sequelize.INTEGER,
+    status: {
+      type: Sequelize.ENUM,
+      values: ['like', 'dislike', 'neutral'],
+    },
+
+  }, {});
+  Like.associate = function (models) {
+    Like.belongsTo(models.Article, {
+      foreignKey: 'articleId',
+      onDelete: 'CASCADE',
+    });
+  };
+  return Like;
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ import auth from './auth';
 import users from './users';
 import errorhandler from '../helpers/exceptionHandler/errorHandler';
 import articles from './article';
+import like from './like';
 
 
 const router = Router();
@@ -12,6 +13,7 @@ router.use(
   auth,
   users,
   articles,
+  like,
   errorhandler,
 );
 

--- a/routes/like/index.js
+++ b/routes/like/index.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import likeType from './router';
+
+const router = Router();
+
+router.use('/articles', likeType);
+
+export default router;

--- a/routes/like/router.js
+++ b/routes/like/router.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import asyncCatchErrors from '../../middlewares/asyncCatchErrors';
+import LikesController from '../../controllers/article/LikesController';
+import LikeValidator from '../../middlewares/validators/LikeValidator';
+
+const router = Router();
+
+router.post('/likes/:slug/:status', LikeValidator.addLikeValidator, asyncCatchErrors(LikesController.addLike));
+
+
+export default router;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -541,6 +541,38 @@ paths:
       - Users
       security:
         - UserSecurity: []
+  "/articles//likes/{slug}/{status}":
+    post:
+      summary: Create new like
+      description: >-
+       The route allows Authenticated users to like, dislike or neutral on any articles
+      parameters:
+        - name: slug
+          in: path
+          description: article unique slug
+          schema:
+            $ref: "#/definitions/LikeRequest"
+        - name: status
+          in: path
+          description: like, dislike or neutral
+          schema:
+            $ref: "#/definitions/LikeRequest"
+      responses:
+        201:
+          description: successfully liked an article
+          schema:
+            $ref: "#/definitions/LikeResult"
+        200:
+          description: successfully modified like status
+          schema:
+            $ref: "#/definitions/LikeResult"
+        400:
+          description: status can only be either like, dislike or neutral.
+          schema:
+            $ref: "#/definitions/Error"
+      tags:
+        - Articles
+
 
   /users/reset-password/begin:
     post:
@@ -955,3 +987,28 @@ definitions:
       message:
         type: string
         example: Password has been successfully reset!.
+
+
+  LikeRequest:
+    required:
+      - slug
+      - status
+    properties:
+     slug:
+      type: string
+      example: My-awesome-article-hammed
+    status:
+      type: string
+      example: like
+  LikeResult:
+      message:
+        type: string
+        example: successfully liked an article
+    
+  properties:
+      status:
+        type: string
+        example: error
+      message:
+        type: string
+        example: user already liked this article

--- a/tests/routes/likeArticle.test.js
+++ b/tests/routes/likeArticle.test.js
@@ -1,0 +1,99 @@
+
+
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../../index';
+import db from '../../models/index';
+import Authorization from '../../middlewares/Authorization';
+
+let Slug;
+let accessToken;
+chai.use(chaiHttp);
+chai.should();
+
+const { User } = db;
+describe('Like or Dislike', () => {
+  before('Login a user', (done) => {
+    User.create({ username: 'hammed', email: 'hammed.noibi@andela.com', password: 'password' }).then((user) => {
+      accessToken = Authorization.generateToken(user.id);
+      done();
+    });
+  });
+  before('create article', (done) => {
+    chai.request(server)
+      .post('/api/v1/articles')
+      .set('Authorization', `Bearer: ${accessToken}`)
+      .send({
+        body: 'hbdbdb dbbdtttttbdbbdbdd',
+        title: 'firts article',
+        description: 'aertttttsjjhhshshshshsh'
+      })
+      .end((err, res) => {
+        Slug = res.body.article.slug;
+        done();
+      });
+  });
+  describe('Like controller', () => {
+    it('should able to like an article ', (done) => {
+      chai.request(server)
+        .post(`/api/v1/articles/likes/${Slug}/like`)
+        .set('Authorization', `Bearer: ${accessToken}`)
+        .send({})
+        .end((err, res) => {
+          res.should.have.status(201);
+          res.body.should.have.property('status');
+          res.body.should.have.property('message');
+
+          done();
+        });
+    });
+    it('should be able to dislike an article', (done) => {
+      chai.request(server)
+        .post(`/api/v1/articles/likes/${Slug}/dislike`)
+        .set('Authorization', `Bearer: ${accessToken}`)
+        .send({})
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.property('status');
+          res.body.should.have.property('message');
+          done();
+        });
+    });
+    it('should be able to stay neutral', (done) => {
+      chai.request(server)
+        .post(`/api/v1/articles/likes/${Slug}/neutral`)
+        .set('Authorization', `Bearer: ${accessToken}`)
+        .send({})
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.property('status');
+          res.body.should.have.property('message');
+          done();
+        });
+    });
+    it('should not be able like article not availabe', (done) => {
+      chai.request(server)
+        .post('/api/v1/articles/likes/dummy-slug-134/dislike')
+        .set('Authorization', `Bearer: ${accessToken}`)
+        .send({})
+        .end((err, res) => {
+          res.should.have.status(404);
+          res.body.should.have.property('status');
+          res.body.should.have.property('message');
+          done();
+        });
+    });
+    it('should not be able like article not availabe', (done) => {
+      chai.request(server)
+        .post('/api/v1/articles/likes/dummy-slug-134/anythingelse')
+        .set('Authorization', `Bearer: ${accessToken}`)
+        .send({})
+        .end((err, res) => {
+          res.should.have.status(400);
+          res.body.should.have.property('status');
+          res.body.should.have.property('message');
+          done();
+        });
+    });
+  });
+});

--- a/tests/services/mail.test.js
+++ b/tests/services/mail.test.js
@@ -11,6 +11,6 @@ describe('sendPasswordReset() method', () => {
         expect(res).to.have.property('status')
           .that.is.equal('success');
         done();
-      });
+      })
   });
 });


### PR DESCRIPTION
#### What does this PR do?
This PR will allow authenticated users to Like or Dislike article
#### Description of Task to be completed?

- Adds addLike, disLike and unLike controllers
- Adds Tests for  addLike, disLike and unLike controllers
- Update Swagger.yaml for like or dislike documentation.

#### How should this be manually tested?
```$xslt
>  git checkout ft-160452484-LikeAndDislike 
> git pull
> npm install 
``` 
>  Then run a POST request with without request body, on POSTMAN 
`localhost:3000/api/v1/articles/${slug}/like`  to like an article and a DELETE request  `localhost:3000/api/v1/articles/${slug}/like` to unlike an article already like by the same user. 

>  Also for the disLike run a POST request to 
`localhost:3000/api/v1/articles/${slug}/dislike`  and to remove dislike an article run a DELETE request  `localhost:3000/api/v1/articles/${slug}/dislike` 

#### Any background context you want to provide?
Nil
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/160452484
#### Screenshots (if appropriate)
Nil
#### Questions:
Nil