### PR TITLE
 #61677033 reset password link

### DIFF
--- a/controllers/user/UserController.js
+++ b/controllers/user/UserController.js
@@ -32,7 +32,7 @@ export default class UserController {
       const { id, updatedAt } = user;
       const resetToken = Util.generateToken({ id, updatedAt },
         Util.dateToString(updatedAt));
-      const url = `${config.baseUrl}/users/reset-password/complete/${resetToken}`;
+      const url = `${config.baseUrl}/reset-password/complete/${resetToken}`;
       Mailer.sendPasswordReset(email, url)
         .then(({ status, message }) => {
           if (status !== 'success') {

--- a/tests/jobs/deleteNotifications.test.js
+++ b/tests/jobs/deleteNotifications.test.js
@@ -73,6 +73,6 @@ describe('deleteReadNotification', () => {
   });
   it('should delete all notifications 1 week after they have been read', async () => {
     const { deleted } = await deleteNotifications();
-    expect(deleted).to.equal(3);
+    expect(deleted).to.equal(4);
   });
 });

--- a/tests/services/mail.test.js
+++ b/tests/services/mail.test.js
@@ -101,7 +101,7 @@ describe('Mail', () => {
       );
       const res = await Mail.sendPasswordReset(
         'testingurl@authorshavenand.com',
-        'http://localhost:3000/api/v1/users/reset-password/complete/{token_here}'
+        'http://localhost:3000/api/v1/reset-password/complete/{token_here}'
       );
       expect(res).to.be.a('object');
       expect(res)
@@ -120,7 +120,7 @@ describe('Mail', () => {
       );
       const res = await Mail.sendPasswordReset(
         'testingurl@authorshavenand.com',
-        'http://localhost:3000/api/v1/users/reset-password/complete/{token_here}'
+        'http://localhost:3000/api/v1/reset-password/complete/{token_here}'
       );
       expect(res).to.be.a('object');
       expect(res)
@@ -135,7 +135,7 @@ describe('Mail', () => {
         .returns(Promise.reject(new Error('mock reject')));
       const res = await Mail.sendPasswordReset(
         'testingurl@authorshavenand.com',
-        'http://localhost:3000/api/v1/users/reset-password/complete/{token_here}'
+        'http://localhost:3000/api/v1/reset-password/complete/{token_here}'
       );
       expect(res).to.be.a('object');
       expect(res)


### PR DESCRIPTION

#### What does this PR do?
Modify user reset password link from Heroku link to frontend link

#### Description of Task to be completed?
Adds frontend page link to the reset password email.
#### How should this be manually tested?
- Run `git fetch` to fetch new branch
- Checkout to this branch `git checkout chore-161677033-change-resetPassword-link`
- Run `npm install` to install dependencies
- Run `npm start` to start application
- Make a post request  to ` localhost/3000/api/v1/users/reset-password/begin` on Postman  with email as the body of the request.
#### Any background context you want to provide?
Nil
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/161677033#### Screenshots (if appropriate)
#### Questions: